### PR TITLE
Use identifier→title menu items for navigation and set cell titles

### DIFF
--- a/Ausktatija National Park/NavigationViewController.m
+++ b/Ausktatija National Park/NavigationViewController.m
@@ -15,14 +15,27 @@
 
 @implementation NavigationViewController {
     
-    NSArray *menu;
+    NSArray<NSDictionary<NSString *, NSString *> *> *menuItems;
     
 }
 
 - (void)viewDidLoad {
     [super viewDidLoad];
     
-    menu = @[@"one",@"two", @"three", @"four",@"five",@"six",@"seven",@"eight",@"nine",@"ten",@"eleven",@"twelve"];
+    menuItems = @[
+        @{@"identifier": @"one", @"title": @"About the Park"},
+        @{@"identifier": @"two", @"title": @"Emergency Contact"},
+        @{@"identifier": @"three", @"title": @"Photos"},
+        @{@"identifier": @"four", @"title": @"How to get there"},
+        @{@"identifier": @"five", @"title": @"Lakes"},
+        @{@"identifier": @"six", @"title": @"National Park Map"},
+        @{@"identifier": @"seven", @"title": @"Bicycle Trail"},
+        @{@"identifier": @"eight", @"title": @"Kayak Routes"},
+        @{@"identifier": @"nine", @"title": @"Camping Grounds"},
+        @{@"identifier": @"ten", @"title": @"Lodging"},
+        @{@"identifier": @"eleven", @"title": @"Historic Sites"},
+        @{@"identifier": @"twelve", @"title": @"Local Events"}
+    ];
     
 }
 
@@ -43,17 +56,17 @@
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
 
     // Return the number of rows in the section.
-    return [menu count];
+    return [menuItems count];
 }
 
 
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
     
     
-    NSString *cellIdentifier = [menu objectAtIndex:indexPath.row];
+    NSDictionary<NSString *, NSString *> *menuItem = menuItems[indexPath.row];
+    NSString *cellIdentifier = menuItem[@"identifier"];
     UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier: cellIdentifier forIndexPath:indexPath];
-    
-    // Configure the cell...
+    cell.textLabel.text = menuItem[@"title"];
     
     return cell;
 }
@@ -66,7 +79,7 @@
     // Set the title of navigation bar by using the menu items
     NSIndexPath *indexPath = [self.tableView indexPathForSelectedRow];
     UINavigationController *destViewController = (UINavigationController*)segue.destinationViewController;
-    destViewController.title = [[menu objectAtIndex:indexPath.row] capitalizedString];
+    destViewController.title = menuItems[indexPath.row][@"title"];
     
     
 }


### PR DESCRIPTION
### Motivation
- Replace the previous flat list of reuse identifiers with structured menu metadata so each menu entry carries both a storyboard `reuseIdentifier` and a user-facing `title`.
- Make table cells show readable section titles and ensure destination view controller titles come from the same source of truth.
- Improve maintainability when adding or reordering menu items.

### Description
- Replaced `NSArray *menu` with `NSArray<NSDictionary<NSString *, NSString *> *> *menuItems` in `NavigationViewController.m`.
- Added menu entries as dictionaries mapping `@"identifier"` -> reuse identifier and `@"title"` -> user-facing label.
- Updated `tableView:numberOfRowsInSection:` and `tableView:cellForRowAtIndexPath:` to use `menuItems`, dequeue cells by `identifier` and set `cell.textLabel.text` from the `title` field.
- Updated `prepareForSegue:` to set the destination navigation controller title using `menuItems[indexPath.row][@"title"]`.

### Testing
- No automated tests were executed as part of this change.
- Recommend opening the project in Xcode and building / running the app to verify the menu labels and segue titles appear as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69455d2503f8832785561bde82ebd717)